### PR TITLE
Fixed misspelling in es-ES.json

### DIFF
--- a/applications/pass-desktop/locales/es_ES.json
+++ b/applications/pass-desktop/locales/es_ES.json
@@ -180,7 +180,7 @@
         "Contraseñas generadas"
       ],
       "Get mobile apps": [
-        "Descargar las aplicaciiones móviles"
+        "Descargar las aplicaciones móviles"
       ],
       "Get Started": [
         "Comenzar"

--- a/applications/pass-desktop/locales/es_ES.json
+++ b/applications/pass-desktop/locales/es_ES.json
@@ -570,6 +570,12 @@
       "Moving item failed": [
         "Error al mover el elemento"
       ],
+      "Offline mode is currently not available for two password mode.": [
+        "El modo sin conexión no está disponible actualmente para el modo de dos contraseñas."
+      ],
+      "Offline mode isn't currently available for your plan and not compatible with two password mode.": [
+        "El modo sin conexión no está disponible actualmente para su plan y no es compatible con el modo de dos contraseñas."
+      ],
       "Passphrase is incorrect": [
         "La frase contraseña es incorrecta."
       ],

--- a/applications/pass-extension/locales/es_ES.json
+++ b/applications/pass-extension/locales/es_ES.json
@@ -207,7 +207,7 @@
         "Contraseñas generadas"
       ],
       "Get mobile apps": [
-        "Descargar las aplicaciiones móviles"
+        "Descargar las aplicaciones móviles"
       ],
       "Help us improve": [
         "Ayúdanos a mejorar"


### PR DESCRIPTION
Within the Spanish localization file was a duplicate letter that damaged the visual experience for the user.